### PR TITLE
feat: Add function to create uniform answer distribution

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -3,6 +3,7 @@ import pandas as pd
 from tqdm import tqdm
 from ast import literal_eval
 from datasets import Dataset
+from src.utils import make_answers_uniform, print_answer_distribution
 
 
 class MyDataset:
@@ -11,6 +12,18 @@ class MyDataset:
             self.prompt = yaml.full_load(f)
 
     def process(self, dataset_df, mode='train'):
+        if mode == "train":
+            # print answer distribution
+            print()
+            print("*" * 50)
+            print_answer_distribution(dataset_df, "Original")
+            print("*" * 50)
+                    
+            dataset_df = make_answers_uniform(dataset_df)
+
+            print_answer_distribution(dataset_df, "Processed Train")
+            print("*" * 50)        
+        
         records = []
         for _, row in dataset_df.iterrows():
             problems = literal_eval(row['problems'])

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,10 @@ import torch
 from trl import SFTConfig
 from peft import LoraConfig
 from transformers import BitsAndBytesConfig
+import pandas as pd
+import ast
+import random
+from collections import Counter
 
 def get_peft_config(config):
     config = LoraConfig(
@@ -53,7 +57,118 @@ def get_quant_config(config):
         )
     elif config['4bit_or_8bit'] == 8:
         quantization_config = BitsAndBytesConfig(
-            load_in_8bit=True
+            load_in_8bit=True,
+            bnb_8bit_compute_dtype=dtype,
+            bnb_8bit_use_double_quant=config['double_quant'],
+            bnb_8bit_quant_type=config['quant_type']
         )
 
     return quantization_config
+
+
+def make_answers_uniform(dataframe, seed=42):
+    """
+    This function creates a dataset with uniform answer distribution.
+    """
+    random.seed(seed)
+
+    # randomly select one of the answers with the minimum count
+    def get_random_min_answer(answer_counts):
+        min_value = min(answer_counts.values())
+        min_keys = [key for key, value in answer_counts.items() if value == min_value]
+        return random.choice(min_keys)
+
+    # shuffle answer choices uniformly
+    def shuffle_answer_position(row, answer_counts):
+        choices = row["choices"]
+        answer = row["answer"]
+
+        # get answer position which has the minimum count
+        answer_position = get_random_min_answer(answer_counts)
+        answer_counts[answer_position] += 1
+
+        # swap
+        new_choices = choices.copy()
+        new_choices[answer_position - 1], new_choices[answer - 1] = (
+            new_choices[answer - 1],
+            new_choices[answer_position - 1],
+        )
+
+        return new_choices, answer_position
+
+    def dic_to_str(row):
+
+        return str(
+            {
+                "question": row["question"],
+                "choices": row["choices_u"],
+                "answer": row["answer_u"],
+            }
+        )
+
+    # convert string to dictionary and add columns
+    dataframe["problems_dict"] = dataframe["problems"].apply(ast.literal_eval)
+    dataframe["question"] = dataframe["problems_dict"].apply(lambda x: x["question"])
+    dataframe["choices"] = dataframe["problems_dict"].apply(lambda x: x["choices"])
+    dataframe["answer"] = dataframe["problems_dict"].apply(lambda x: x["answer"])
+
+    # divide the dataset into two parts based on the number of choices
+    sub_train_4 = dataframe[dataframe["choices"].apply(len) == 4].copy()
+    sub_train_5 = dataframe[dataframe["choices"].apply(len) == 5].copy()
+
+    # initialize answer distribution
+    answer_counts_4 = Counter({i: 0 for i in range(1, 5)})  # 4지 선다 정답 분포 초기화
+    answer_counts_5 = Counter({i: 0 for i in range(1, 6)})  # 5지 선다 정답 분포 초기화
+
+    # shuffle answer choices uniformly
+    sub_train_4[["choices_u", "answer_u"]] = pd.DataFrame(
+        sub_train_4.apply(
+            shuffle_answer_position, axis=1, answer_counts=answer_counts_4
+        ).tolist(),
+        index=sub_train_4.index,
+    )
+    sub_train_5[["choices_u", "answer_u"]] = pd.DataFrame(
+        sub_train_5.apply(
+            shuffle_answer_position, axis=1, answer_counts=answer_counts_5
+        ).tolist(),
+        index=sub_train_5.index,
+    )
+
+    # combine the two datasets
+    train_uniform = (
+        pd.concat([sub_train_4, sub_train_5])
+        .sample(frac=1, random_state=42)
+        .reset_index(drop=True)
+    )
+
+    # convert dictionary to string
+    train_uniform["problems_u"] = train_uniform.apply(dic_to_str, axis=1)
+    train_uniform["problems"] = train_uniform["problems_u"]
+    
+    drop_columns = [
+        "problems_dict",
+        "question",
+        "choices",
+        "answer",
+        "choices_u",
+        "answer_u",
+    ]
+    train_uniform = train_uniform.drop(columns=drop_columns)
+
+    return train_uniform
+    
+
+def print_answer_distribution(dataframe, tag="Train"):
+    """
+    PRINT ANSWER DISTRIBUTION
+    """
+    dataframe = dataframe.copy()
+    dataframe["problems_dict"] = dataframe["problems"].apply(ast.literal_eval)
+    dataframe["answer"] = dataframe["problems_dict"].apply(lambda x: x["answer"])
+
+    print(f"{tag} Answer distribution")
+    answer_counts = dataframe["answer"].value_counts().sort_index()
+    answer_ratios = dataframe["answer"].value_counts(normalize=True).sort_index().round(2)
+    result = pd.DataFrame({"Count": answer_counts, "Ratio": answer_ratios})
+
+    print(result)


### PR DESCRIPTION
## Overview
- 정답 분포를 균등하게 만드는 함수 make_answer_uniform 추가
- 데이터셋에서 정답 선택지를 랜덤으로 섞고, 정답이 고르게 분포되도록 처리
## Change Log
- make_answers_uniform 함수 구현:
  - 4지 선다와 5지 선다 문제를 별도로 처리하여 정답 분포를 균등하게 맞춤.
  - 데이터셋에서 문제, 선택지, 정답을 추출해서 가공
  - 정답 위치를 균등하게 재분배 후, 데이터셋을 변환
  - 중간 처리에 사용된 컬럼 제거
 - make_answers_uniform 함수 적용:
   - utils.py에 함수로 추가
   - dataset.py의 process()에서 처리
   - main.py -> dataset.py로 넘어가는 지점(train set이 가공되기 시작하는 첫 지점)에서 처리
## To Reviewer
- 검토 사항:
  - 정답 분포 균등화 로직의 정확성
  - 데이터셋에 대한 처리 로직
  - seed=42를 사용한 랜덤화의 일관성
  - 각종 edge cases
## Issue Tags
- Closed | Fixed: #
- See also: #
